### PR TITLE
separate OdmlDtype definition and consistency check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ coverage.xml
 # Django stuff:
 *.log
 
+# PyCharm project files:
+.idea/
+
 # Sphinx documentation
 docs/_build/
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ var/
 .installed.cfg
 *.egg
 
+# Temporary files
+*~
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/odmltables/odml_csv_table.py
+++ b/odmltables/odml_csv_table.py
@@ -46,6 +46,8 @@ class OdmlCsvTable(OdmlTable):
 
             csvwriter.writeheader()
 
+            self.consistency_check()
+
             for dic in self._odmldict:
                 # create a copy of the dictionary, so nothing in the odml_dict
                 # will be changed

--- a/odmltables/odml_table.py
+++ b/odmltables/odml_table.py
@@ -506,6 +506,37 @@ class OdmlTable(object):
             for del_prop in del_props:
                 self.filter(invert=True,recursive=True,comparison_func= lambda x,y: x.startswith(y),Path=del_prop['Path'])
 
+    def merge(self,odmltable):
+        """
+        Merge odmltable into current odmltable.
+        :param odmltable: OdmlTable object or Odml document object
+        :return:
+        """
+        if hasattr(odmltable,'_convert2odml'):
+            doc2 = odmltable._convert2odml()
+        else:
+            # assuming odmltable is already an odml document
+            doc2 = odmltable
+        doc1 = self._convert2odml()
+
+        for sec in doc2:
+            if sec.name in doc1.sections:
+                doc1.sections[sec.name].merge(sec)
+            else:
+                doc1.append(sec)
+
+
+        #TODO: What should happen to the document properties?
+        """
+        'author'
+        'date'
+        'version'
+        'repository'
+        """
+
+        #TODO: Check what happens to original odmldict...
+        self.load_from_odmldoc(doc1)
+
 
     def write2file(self, save_to):
         """
@@ -515,11 +546,12 @@ class OdmlTable(object):
 
         self.consistency_check()
 
-    def write2odml(self, save_to):
-        """
-        writes the loaded odmldict (e.g. from an csv-file) to an odml-file
-        """
 
+    def _convert2odml(self):
+        """
+        Generates odml representation of odmldict and return it as odml document.
+        :return:
+        """
         doc = odml.Document()
         oldpath = []
         oldpropname = ''
@@ -585,6 +617,14 @@ class OdmlTable(object):
             prop.definition = oldpropdef
         parent.append(prop)
 
+        return doc
+
+
+    def write2odml(self, save_to):
+        """
+        writes the loaded odmldict (e.g. from an csv-file) to an odml-file
+        """
+        doc = self._convert2odml()
         odml.tools.xmlparser.XMLWriter(doc).write_file(save_to)
 
 

--- a/odmltables/odml_table.py
+++ b/odmltables/odml_table.py
@@ -326,7 +326,7 @@ class OdmlTable(object):
                 elif dtype in ['string', 'text', 'person', 'url']:
                     current_dic['Value'] = str(current_dic['Value'])
                 else:
-                    raise Exception('unknown datatype!!')
+                    raise Exception('Unknown datatype {0}!!'.format(dtype))
                     # TODO: change exception?!
 
                 self._odmldict.append(current_dic)

--- a/odmltables/odml_table.py
+++ b/odmltables/odml_table.py
@@ -641,9 +641,9 @@ class OdmlDtypes(object):
     default_basedtypes = {'int':-1,
                   'float':-1.0,
                   'bool':False,
-                  'datetime':datetime.datetime(1111,11,11,11,11,11),
-                  'datetime.date':datetime.datetime(1111,11,11).date(),
-                  'datetime.time':datetime.datetime(1111,11,11,11,11,11).time(),
+                  'datetime':datetime.datetime(1900,01,01,01,01,01),
+                  'datetime.date':datetime.datetime(1900,01,01).date(),
+                  'datetime.time':datetime.datetime(1900,01,01,01,01,01).time(),
                   'str':'-',
                   'url':'file://-'}
     default_synonyms = {'boolean':'bool','date':'datetime.date','time':'datetime.time',

--- a/odmltables/odml_table.py
+++ b/odmltables/odml_table.py
@@ -323,7 +323,7 @@ class OdmlTable(object):
                 elif dtype == 'date':
                     current_dic['Value'] = \
                         datetime.datetime.strptime(value, '%Y-%m-%d').date()
-                elif dtype in ['string', 'text', 'person']:
+                elif dtype in ['string', 'text', 'person', 'url']:
                     current_dic['Value'] = str(current_dic['Value'])
                 else:
                     raise Exception('unknown datatype!!')

--- a/odmltables/odml_xls_table.py
+++ b/odmltables/odml_xls_table.py
@@ -145,6 +145,8 @@ class OdmlXlsTable(OdmlTable):
             sheet.write(0, col, self._header_titles[h] if h in
                         self._header_titles else "", styles['header'])
 
+        self.consistency_check()
+
         # write the rows
         for dic in self._odmldict:
 

--- a/tests/create_test_odmls.py
+++ b/tests/create_test_odmls.py
@@ -197,29 +197,47 @@ def create_datatype_test_odml():
     return doc
 
 
-def create_compare_test(sections=3, properties=3):
+def create_compare_test(sections=3, properties=3,levels=1):
     """
     """
 
     doc = odml.Document()
 
-    for i in range(sections):
-        doc.append(odml.Section(name='Section' + str(i+1)))
-        parent = doc['Section' + str(i+1)]
-        if(i != 2):
-            for j in range(properties):
-                parent.append(odml.Property(name='Property' + str(j+1), value= i+j))
-        else:
-            for j in range(properties-2):
-                parent.append(odml.Property(name='Property' + str(j+1), value= i+j))
-            parent.append(odml.Property(name='Property' + str(properties), value= i+properties-1))
+    def append_children(sec,level):
+        if level < levels:
+            for i in range(sections):
+                sec.append(odml.Section(name='Section' + str(i+1)))
+                parent = sec['Section' + str(i+1)]
+                append_children(parent,level+1)
+                if(i != 2):
+                    for j in range(properties):
+                        parent.append(odml.Property(name='Property' + str(j+1), value= i+j))
+                else:
+                    for j in range(properties-2):
+                        parent.append(odml.Property(name='Property' + str(j+1), value= i+j))
+                    parent.append(odml.Property(name='Property' + str(properties), value= i+properties-1))
+
+    # sec = doc
+    # for l in range(levels):
+    #     for i in range(sections):
+    #         doc.append(odml.Section(name='Section' + str(i+1)))
+    #         parent = doc['Section' + str(i+1)]
+    #         if(i != 2):
+    #             for j in range(properties):
+    #                 parent.append(odml.Property(name='Property' + str(j+1), value= i+j))
+    #         else:
+    #             for j in range(properties-2):
+    #                 parent.append(odml.Property(name='Property' + str(j+1), value= i+j))
+    #             parent.append(odml.Property(name='Property' + str(properties), value= i+properties-1))
+
+
+    append_children(doc,0)
 
     doc.append(odml.Section(name='One more Section'))
     parent = doc['One more Section']
     parent.append(odml.Property(name='Property2', value=11))
 
     return doc
-
 
 
 

--- a/tests/test_odml_table.py
+++ b/tests/test_odml_table.py
@@ -13,6 +13,7 @@ from odmltables.odml_xls_table import OdmlXlsTable
 import unittest
 from create_test_odmls import create_small_test_odml
 from create_test_odmls import create_showall_test_odml
+from create_test_odmls import create_compare_test
 import os
 
 
@@ -248,6 +249,86 @@ class TestOdmlTable(unittest.TestCase):
         # TODO: Exception aendern
         with self.assertRaises(Exception):
             self.test_table.allow_empty_columns = False
+
+
+class TestFilter(unittest.TestCase):
+    """
+    class to test the other functions of the OdmlTable-class
+    """
+
+    def setUp(self):
+        self.test_table = OdmlTable()
+        self.test_table.load_from_odmldoc(create_compare_test(levels=2))
+
+    def test_filter_errors(self):
+        """
+        test filter function for exceptions
+        """
+
+        with self.assertRaises(ValueError):
+            self.test_table.filter()
+
+        with self.assertRaises(ValueError):
+            self.test_table.filter(mode='wrongmode',Property='Property')
+
+    def test_filter_mode_and(self):
+        """
+        testing mode='and' setting of filter function
+        """
+
+        self.test_table.filter(mode='and',invert=False,SectionName='Section2',PropertyName='Property2')
+        num_props_new = len(self.test_table._odmldict)
+
+        self.assertEqual(4,num_props_new)
+
+    def test_filter_mode_or(self):
+        """
+        testing mode='or' setting of filter function
+        """
+
+        self.test_table.filter(mode='or',invert=False,SectionName='Section2',PropertyName='Property2')
+        num_props_new = len(self.test_table._odmldict)
+
+        self.assertEqual(17,num_props_new)
+
+    def test_filter_invert(self):
+        """
+        testing invert setting of filter function
+        """
+
+        num_props_original = len(self.test_table._odmldict)
+        self.test_table.filter(mode='or',invert=True,SectionName='Section2',PropertyName='Property2')
+        num_props_new = len(self.test_table._odmldict)
+
+        self.assertEqual(num_props_original-17,num_props_new)
+
+    def test_filter_recursive(self):
+        """
+        testing recursive setting of filter function
+        """
+
+        self.test_table.filter(mode='and',recursive=True,invert=True,SectionName='Section2')
+        num_props_new = len(self.test_table._odmldict)
+
+        self.assertEqual(16,num_props_new)
+
+
+    def test_filter_comparison_func_false(self):
+        """
+        keeping/removing all properties by providing True/False as comparison function
+        """
+
+        num_props_original = len(self.test_table._odmldict)
+        self.test_table.filter(comparison_func=lambda x,y:True,PropertyName='')
+        self.assertEqual(len(self.test_table._odmldict),num_props_original)
+
+        self.test_table.filter(comparison_func=lambda x,y:False,PropertyName='')
+        self.assertEqual(len(self.test_table._odmldict),0)
+
+
+
+
+
 
 
 if __name__ == '__main__':

--- a/tests/test_odml_table.py
+++ b/tests/test_odml_table.py
@@ -16,6 +16,7 @@ from create_test_odmls import create_small_test_odml
 from create_test_odmls import create_showall_test_odml
 from create_test_odmls import create_compare_test
 import os
+import copy
 
 
 class TestLoadOdmlFromTable(unittest.TestCase):
@@ -250,6 +251,34 @@ class TestOdmlTable(unittest.TestCase):
         # TODO: Exception aendern
         with self.assertRaises(Exception):
             self.test_table.allow_empty_columns = False
+
+    def test_merge(self):
+        doc1 = create_compare_test(sections=2,properties=2,levels=2)
+        # generate one additional Property, which is not present in doc2
+        doc1.sections[0].append(odml.Property(name='Doc1Property2',value=5))
+        #generate one additional Section, which is not present in doc2
+        new_prop = odml.Property(name='Doc1Property2',value=10)
+        new_sec = odml.Section(name='Doc1Section')
+        new_sec.append(new_prop)
+        doc1.sections[0].append(new_sec)
+        self.test_table.load_from_odmldoc(doc1)
+
+        doc2 = create_compare_test(sections=3,properties=3,levels=3)
+        table2 = OdmlTable()
+        table2.load_from_odmldoc(doc2)
+
+        backup_table = copy.deepcopy(self.test_table)
+
+        self.test_table.merge(doc2)
+        backup_table.merge(table2)
+
+        self.assertListEqual(self.test_table._odmldict,backup_table._odmldict)
+
+        expected = len(table2._odmldict) + 2
+
+        self.assertEqual(len(self.test_table._odmldict),expected)
+
+        pass
 
 
 class TestFilter(unittest.TestCase):

--- a/tests/test_odml_table.py
+++ b/tests/test_odml_table.py
@@ -7,6 +7,7 @@ Created on Fri Apr 17 08:11:32 2015
 
 import odml
 from odmltables.odml_table import OdmlTable
+from odmltables.odml_table import OdmlDtypes
 from odmltables.odml_csv_table import OdmlCsvTable
 from odmltables.odml_xls_table import OdmlXlsTable
 
@@ -324,6 +325,64 @@ class TestFilter(unittest.TestCase):
 
         self.test_table.filter(comparison_func=lambda x,y:False,PropertyName='')
         self.assertEqual(len(self.test_table._odmldict),0)
+
+
+class TestOdmlDtypes(unittest.TestCase):
+    """
+    class to test the other functions of the OdmlDtype-class
+    """
+
+    def setUp(self):
+        self.test_dtypes = OdmlDtypes()
+
+    def test_defaults(self):
+
+        expected_basedtypes = self.test_dtypes.default_basedtypes.keys()
+        self.assertItemsEqual(expected_basedtypes,self.test_dtypes.basedtypes)
+
+        expected_synonyms = self.test_dtypes.default_synonyms
+        self.assertEqual(expected_synonyms,self.test_dtypes.synonyms)
+
+    def test_valid_dtypes(self):
+        expected_dtypes = self.test_dtypes.default_basedtypes.keys() + self.test_dtypes.default_synonyms.keys()
+        self.assertItemsEqual(expected_dtypes,self.test_dtypes.valid_dtypes)
+
+    def test_default_values(self):
+        basedefaults = self.test_dtypes.default_basedtypes
+        syndefaults = dict([(syn,basedefaults[base]) for syn,base in self.test_dtypes.default_synonyms.iteritems()])
+        expected_defaults = basedefaults.copy()
+        expected_defaults.update(syndefaults)
+
+        self.assertEqual(expected_defaults,self.test_dtypes.default_values)
+
+        for dtype,expected_default in expected_defaults.iteritems():
+            self.assertEqual(expected_default,self.test_dtypes.default_value(dtype))
+
+    def test_synonym_adder(self):
+        basedtype, synonym = ('int','testsyn1')
+        self.test_dtypes.add_synonym(basedtype,synonym)
+
+        expected_synonyms = self.test_dtypes.default_synonyms.copy()
+        expected_synonyms.update({synonym:basedtype})
+        self.assertEqual(self.test_dtypes.synonyms, expected_synonyms)
+        self.assertEqual(self.test_dtypes.default_value('testsyn1'),self.test_dtypes.default_value('int'))
+
+    def test_basedtype_adder(self):
+        basedtype, default = 'testbasetype','testdefault'
+        self.test_dtypes.add_basedtypes(basedtype,default)
+
+        expected_basedtypes = self.test_dtypes.default_basedtypes.copy()
+        expected_basedtypes.update({basedtype:default})
+        self.assertItemsEqual(self.test_dtypes.basedtypes,expected_basedtypes)
+
+    def test_default_value_setter(self):
+        default_value = 1
+        self.test_dtypes.set_default_value('int',default_value)
+
+        self.test_dtypes.default_value('int')
+
+        self.assertEqual(self.test_dtypes.default_value('int'),default_value)
+
 
 
 


### PR DESCRIPTION
I tried to put the odml dtype handling in a new class to avoid the definition of dtypes at multiple locations in the code. In addition I added the new dtype 'url' and also added a dtype consistency check before saving data. Previously this led to saved files, which could not be loaded any more due to unknown data types.
Please have a look and if you like this implementation I will also add some tests to it.