### PR TITLE
Fix every boolean converting to True when loading from csv

### DIFF
--- a/odmltables/odml_table.py
+++ b/odmltables/odml_table.py
@@ -8,6 +8,7 @@ import copy
 import odml
 import csv
 import datetime
+import warnings
 import xlrd
 
 from future.utils import iteritems
@@ -696,8 +697,8 @@ class OdmlTable(object):
 
                 if comparison_func(dict_prop[filter_key], filter_value):
                     keep_property = True
-                # for comparison of Value entries  we need to compare to the first entry as those 
-                are by default wrapped in a list
+                # for comparison of Value entries  we need to compare to
+                # the first entry as those are by default wrapped in a list
                 elif filter_key == 'Value' and len(dict_prop[filter_key]) == 1:
                     assert type(dict_prop[filter_key]) == list
                     keep_property = comparison_func(dict_prop[filter_key][0], filter_value)
@@ -971,7 +972,15 @@ class OdmlDtypes(object):
         elif dtype == 'float':
             result = float(value)
         elif dtype == 'boolean':
-            result = bool(value)
+            # strip whitespace and convert to lower case
+            value = value.strip().lower()
+            if value in ('y', 'yes', 't', 'true', 'on', '1'):
+                result = True
+            elif value in ('n', 'no', 'f', 'false', 'off', '0'):
+                result = False
+            else:
+                warnings.warn("invalid truth value %r, replacing with None" % (value,))
+                result = None
         elif dtype in ['string', 'text', 'url', 'person']:
             result = str(value)
         else:

--- a/odmltables/tests/test_odml_csv_table.py
+++ b/odmltables/tests/test_odml_csv_table.py
@@ -76,6 +76,24 @@ class TestOdmlCsvTable(unittest.TestCase):
         self.assertEqual(len(table._odmldict), 1)
         self.assertDictEqual(table._odmldict[0], table2._odmldict[0])
 
+    def test_saveload_bool(self):
+        doc = odml.Document()
+        doc.append(odml.Section('sec'))
+        doc[0].append(odml.Property('prop', values=[False]))
+
+        table = OdmlCsvTable()
+        table.load_from_odmldoc(doc)
+        table.change_header('full')
+        table.write2file(self.filename)
+
+        table2 = OdmlTable()
+        table2.load_from_csv_table(self.filename)
+
+        # comparing values which are written to xls by default
+        self.assertEqual(len(table._odmldict), len(table2._odmldict))
+        self.assertEqual(len(table._odmldict), 1)
+        self.assertDictEqual(table._odmldict[0], table2._odmldict[0])
+
     def test_saveload_empty_header(self):
         doc = odml.Document()
 


### PR DESCRIPTION
Fixes #131

I added a test ensuring that a boolean with value `False` survives a write-read-cycle to and from csv.
To fix the issue, I implemented a string-to-bool conversion based on the [distutils function](https://github.com/python/cpython/blob/v3.11.2/Lib/distutils/util.py#L308) which is now deprecated and supposed to be reimplemented in projects that make use of it (see [PEP 632](https://peps.python.org/pep-0632/).